### PR TITLE
Problem: gcc is not always called gcc

### DIFF
--- a/src/c
+++ b/src/c
@@ -154,8 +154,8 @@ fi
 #
 #  Generic modern GCC system
 #
-case "$CCNAME" in
-*gcc*)
+case "$($CCNAME --version)" in
+*gcc*|*GCC*)
     [ -z "$BOOM_MODEL_NOOPT" ] && CCDEBUG="-O2"
     [ -z "$BOOM_MODEL_NOOPT" ] && CCNODEBUG="$CCNODEBUG -O2"
     CCOPTS="-D_REENTRANT -D_GNU_SOURCE -Wall -Wno-unused -fno-strict-aliasing"


### PR DESCRIPTION
Solution: Query the --version string of whatever CCNAME happens to
be. This will catch such misfits as cross compilers, and places
where gcc is invoked as plain old cc.