### PR TITLE
Problem: some systems can't find pcre.h

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -53,6 +53,8 @@ DBG =
 CC = ./c -q
 export CCLIBS = -lpcre
 
+CPPFLAGS ?= -I/usr/include/pcre
+
 # Reset the suffixes that will be considered to just our own list.
 #
 # Make programs use the .SUFFIXES psuedo rule for this


### PR DESCRIPTION
Solution: help by optionally pre-populating a CPPFLAGS value

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>