### PR TITLE
Problem: get_abbrev_day/month return local variable

### DIFF
--- a/src/sfl.h
+++ b/src/sfl.h
@@ -1988,9 +1988,9 @@ Bool  get_accents         (void);
 char *get_units_name      (int units);
 char *get_tens_name       (int tens);
 char *get_day_name        (int day);
-char *get_day_abbrev      (int day, Bool upper);
+char *get_day_abbrev      (int day, Bool upper, char *dest);
 char *get_month_name      (int month);
-char *get_month_abbrev    (int month, Bool upper);
+char *get_month_abbrev    (int month, Bool upper, char *dest);
 char *timestamp_string    (char *buffer, const char *pattern);
 char *certify_the_number  (char *buffer, int buffer_size, long number,
                            char *language, int code_page);

--- a/src/sfllang.c
+++ b/src/sfllang.c
@@ -594,21 +594,20 @@ get_day_name (int day)
     a value from 0 (Sunday) to 6 (Saturday).  The abbreviation (3 letters)
     is converted into uppercase if the 'upper' argument is true.  Accented
     characters are formatted according to the current accents setting.
+    Caller must provide a large enough destination (4 characters including
+    NULL), the function will copy the result into it.
     ---------------------------------------------------------------------[>]-*/
 
 char *
-get_day_abbrev (int day, Bool upper)
+get_day_abbrev (int day, Bool upper, char *dest)
 {
-    char
-        abbrev [4];
-
     ASSERT (day >= 0 && day <= 6);
 
-    strncpy (abbrev, day_table [day], 3);
-    abbrev [3] = '\0';
+    strncpy (dest, day_table [day], 3);
+    dest [3] = '\0';
     if (upper)
-        strupc (abbrev);
-    return (handle_accents (abbrev));
+        strupc (dest);
+    return (handle_accents (dest));
 }
 
 
@@ -635,22 +634,21 @@ get_month_name (int month)
     be a value from 1 to 12.  The abbreviation (3 letters) is converted into
     uppercase if the 'upper' argument is true.  Accented characters are
     formatted according to the current accents setting.
+    Caller must provide a large enough destination (4 characters including
+    NULL), the function will copy the result into it.
     ---------------------------------------------------------------------[>]-*/
 
 char *
-get_month_abbrev (int month, Bool upper)
+get_month_abbrev (int month, Bool upper, char *dest)
 {
-    char
-        abbrev [4];
-
     ASSERT (month >= 1 && month <= 12);
 
-    strncpy (abbrev, month_table [month - 1], 3);
-    abbrev [3] = '\0';
+    strncpy (dest, month_table [month - 1], 3);
+    dest [3] = '\0';
     if (upper)
-        strupc (abbrev);
+        strupc (dest);
 
-    return (handle_accents (abbrev));
+    return (handle_accents (dest));
 }
 
 
@@ -814,7 +812,7 @@ timestamp_string (char *buffer, const char *pattern)
                     sprintf (dest, "%02d", month);
                 else
                 if (cursize == 3)       /*  mmm   month, 3 letters           */
-                    strcpy (dest, get_month_abbrev (month, FALSE));
+                    get_month_abbrev (month, FALSE, dest);
                 else
                 if (cursize == 4)       /*  mmmm  month, full name           */
                     strcpy (dest, get_month_name (month));
@@ -822,7 +820,7 @@ timestamp_string (char *buffer, const char *pattern)
 
             case 'M':
                 if (cursize == 3)       /*  MMM   month, 3-letters, ucase    */
-                    strcpy (dest, get_month_abbrev (month, TRUE));
+                    get_month_abbrev (month, TRUE, dest);
                 else
                 if (cursize == 4)       /*  MMMM  month, full name, ucase    */
                   {
@@ -836,7 +834,7 @@ timestamp_string (char *buffer, const char *pattern)
                     sprintf (dest, "%02d", day);
                 else
                 if (cursize == 3)       /*  ddd   day of week, Sun           */
-                    strcpy (dest, get_day_abbrev (day_of_week (date), FALSE));
+                    get_day_abbrev (day_of_week (date), FALSE, dest);
                 else
                 if (cursize == 4)       /*  dddd  day of week, Sunday        */
                     strcpy (dest, get_day_name (day_of_week (date)));
@@ -844,7 +842,7 @@ timestamp_string (char *buffer, const char *pattern)
 
             case 'D':
                 if (cursize == 3)       /*  DDD   day of week, SUN           */
-                    strcpy (dest, get_day_abbrev (day_of_week (date), TRUE));
+                    get_day_abbrev (day_of_week (date), TRUE, dest);
                 else
                 if (cursize == 4)       /*  DDDD  day of week, SUNDAY        */
                   {

--- a/src/sfllang.h
+++ b/src/sfllang.h
@@ -57,9 +57,9 @@ Bool  get_accents         (void);
 char *get_units_name      (int units);
 char *get_tens_name       (int tens);
 char *get_day_name        (int day);
-char *get_day_abbrev      (int day, Bool upper);
+char *get_day_abbrev      (int day, Bool upper, char *dest);
 char *get_month_name      (int month);
-char *get_month_abbrev    (int month, Bool upper);
+char *get_month_abbrev    (int month, Bool upper, char *dest);
 char *timestamp_string    (char *buffer, const char *pattern);
 char *certify_the_number  (char *buffer, int buffer_size, long number,
                            char *language, int code_page);


### PR DESCRIPTION
Solution: change the functions to take in the destination buffer and use
it instead of returning a local variable.

Fixes https://github.com/imatix/gsl/issues/157