### PR TITLE
Problem: version 4.1.4 still in packaging metadata

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+generator-scripting-language (4.1.5) UNRELEASED; urgency=low
+
+  * Updated release under ZeroMQ community stewardship.
+
+ -- ZeroMQ Community https://github.com/zeromq/gsl/  Wed, Sep 13 15:35:49 2017 +0200
+
 generator-scripting-language (4.1.4) UNRELEASED; urgency=low
 
   * Initial packaging.

--- a/packaging/debian/generator-scripting-language.dsc.obs
+++ b/packaging/debian/generator-scripting-language.dsc.obs
@@ -1,7 +1,7 @@
 Format: 3.0 (native)
 Binary: generator-scripting-language
 Source: generator-scripting-language
-Version: 4.1.4
+Version: 4.1.5
 Maintainer: GSL Developers <zeromq-dev@lists.zeromq.org>
 Architecture: any
 Standards-Version: 4.1.0

--- a/packaging/linux/create_tarball.sh
+++ b/packaging/linux/create_tarball.sh
@@ -2,7 +2,7 @@
 
 PACKAGE_TMP="/tmp"
 PACKAGE_NAME="imatix-gsl"
-PACKAGE_VERSION="4.1.4"
+PACKAGE_VERSION="4.1.5"
 
 SCRIPTS_DIR=$(dirname $(cd ${0%/*} 2>>/dev/null ; echo `pwd`/${0##*/}))
 PROJECT_DIR="$(realpath ${SCRIPTS_DIR}/../../)"

--- a/packaging/linux/rpm/SPECS/generator-scripting-language.spec
+++ b/packaging/linux/rpm/SPECS/generator-scripting-language.spec
@@ -3,7 +3,7 @@
 
 Summary:	imatix GSL is a code construction tool
 Name:		generator-scripting-language
-Version:	4.1.4
+Version:	4.1.5
 Release:	%{revision}%{?dist}
 License:	GPL v3+
 Group:		Libraries

--- a/packaging/nuget/package.config
+++ b/packaging/nuget/package.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- These values are populated into the package.gsl template by package.bat. -->
-<package id="gsl" target="gsl" version="4.1.4.0" />
+<package id="gsl" target="gsl" version="4.1.5.0" />

--- a/packaging/nuget/package.nuspec
+++ b/packaging/nuget/package.nuspec
@@ -7,7 +7,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd">
     <metadata minClientVersion="2.5">
         <id>gsl</id>
-        <version>4.1.4.0</version>
+        <version>4.1.5.0</version>
         <title>gsl</title>
         <authors>Pieter Hintjens and others</authors>
         <owners>Eric Voskuil</owners>

--- a/src/version.h
+++ b/src/version.h
@@ -44,8 +44,8 @@
 #undef  COPYRIGHT
 #undef  BUILDDATE
 #undef  BUILDMODEL
-#define VERSION         "4.1.4"
-#define PRODUCT         "GSL/4.1.4"
+#define VERSION         "4.1.5"
+#define PRODUCT         "GSL/4.1.5"
 #define COPYRIGHT       "Copyright (c) 1996-2016 iMatix Corporation\n              GSL Developers 2016-2017"
 #define BUILDDATE       ""
 #define BUILDMODEL      "Built from http://github.com/zeromq/gsl.git master"


### PR DESCRIPTION
Solution: update to 4.1.5 per release tagged two months ago ;)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>