### PR TITLE
Problem: RPM specfile should want proper dependencies

### DIFF
--- a/packaging/linux/rpm/SPECS/generator-scripting-language.spec
+++ b/packaging/linux/rpm/SPECS/generator-scripting-language.spec
@@ -9,7 +9,11 @@ License:	GPL v3+
 Group:		Libraries
 Source0:	http://download.zeromq.org/gsl-%{version}.tar.gz
 URL:		http://zeromq.org/
-BuildRequires:	pcre-devel
+BuildRequires:	bash
+BuildRequires:	gcc
+BuildRequires:	pcre-devel >= 8
+Requires:	pcre >= 8
+Provides:	generator-scripting-language
 
 BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
 


### PR DESCRIPTION
Solution: Update PCRE requirement to v8+, require a shell and compiler for build, and PCRE for runtime

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>