### PR TITLE
Problem: RPM packaging does not benefit from _smp_mflags

### DIFF
--- a/packaging/linux/rpm/SPECS/generator-scripting-language.spec
+++ b/packaging/linux/rpm/SPECS/generator-scripting-language.spec
@@ -29,7 +29,7 @@ administration tools and much more.
 %setup -q -n gsl-%{version}
 %build
 cd src
-make 
+make %{?_smp_mflags}
 cd ../
 %install
 %{__rm} -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Solution: add the optional parameter to the make magic

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>