### PR TITLE
Problem: no packaging/redhat as expected by zproject-compatible builds

### DIFF
--- a/packaging/redhat/generator-scripting-language.spec
+++ b/packaging/redhat/generator-scripting-language.spec
@@ -1,0 +1,1 @@
+../linux/rpm/SPECS/generator-scripting-language.spec


### PR DESCRIPTION
Solution: add the symlink in location packaging scripts tuned for zproject ecosystem expect

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>