### PR TITLE
Problem: Jenkinsfile deletes workdir before calling deployer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,9 @@ pipeline {
                 sh 'echo "Are GitIgnores good after make install? (should have no output below)"; git status -s || true'
                 script {
                     if ( params.DO_CLEANUP_AFTER_BUILD ) {
-                        deleteDir()
+                        dir("${params.USE_TEST_INSTALL_DESTDIR}") {
+                            deleteDir()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Solution: delete only the installation target dir, if requested

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>