### PR TITLE
Problems: Itanium and RISC-V builds broken

### DIFF
--- a/src/prelude.h
+++ b/src/prelude.h
@@ -93,6 +93,7 @@
     || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
     || defined (__s390x__) || (defined (__sparc__) && defined (__arch64__)) \
     || defined (__ia64) || defined (__itanium__) || defined (_M_IA64) \
+    || defined (__riscv64) || (defined (__riscv_xlen) && __riscv_xlen == 64) \
     || (defined (__mips__) && defined (_MIPSEL) && _MIPS_SIM == _ABI64))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else

--- a/src/prelude.h
+++ b/src/prelude.h
@@ -92,6 +92,7 @@
 #if (defined (__64BIT__) || defined (__x86_64__) || defined (__AARCH64EL__) \
     || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
     || defined (__s390x__) || (defined (__sparc__) && defined (__arch64__)) \
+    || defined (__ia64) || defined (__itanium__) || defined (_M_IA64) \
     || (defined (__mips__) && defined (_MIPSEL) && _MIPS_SIM == _ABI64))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else

--- a/src/sfl.h
+++ b/src/sfl.h
@@ -132,6 +132,7 @@
     || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
     || defined (__s390x__) || (defined (__sparc__) && defined (__arch64__)) \
     || defined (__ia64) || defined (__itanium__) || defined (_M_IA64) \
+    || defined (__riscv64) || (defined (__riscv_xlen) && __riscv_xlen == 64) \
     || (defined (__mips__) && defined (_MIPSEL) && _MIPS_SIM == _ABI64))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else

--- a/src/sfl.h
+++ b/src/sfl.h
@@ -131,6 +131,7 @@
 #if (defined (__64BIT__) || defined (__x86_64__) || defined (__AARCH64EL__) \
     || defined (__PPC64__) || defined (__powerpc64__) || defined (__ppc64__) \
     || defined (__s390x__) || (defined (__sparc__) && defined (__arch64__)) \
+    || defined (__ia64) || defined (__itanium__) || defined (_M_IA64) \
     || (defined (__mips__) && defined (_MIPSEL) && _MIPS_SIM == _ABI64))
 #    define __IS_64BIT__                /*  May have 64-bit OS/compiler      */
 #else


### PR DESCRIPTION
Solution: check the respective preprocessor defines for _IS_64BIT_