### PR TITLE
Closes #31.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ Finally build gsl:
     make
     make install
 
+#### Building on MacOS 
+
+The modern way of building on MacOS is to make sure you have pcre installed and use brew.
+
+    brew install pcre
+
+And then build gsl as above:
+
+    git clone git://github.com/zeromq/gsl
+    cd gsl/src
+    make
+    sudo make install
+
 ### This Document
 
 This document was written by Pieter Hintjens in October 2010 based on two 2005 articles on 'model oriented programming', and the GSL reference manual.  This text is originally at README.txt and is built using [gitdown](http://github.com/zeromq/gitdown). The text was updated by Gyepi Sam in January 2013 to port documentation from earlier versions and to include more examples.
@@ -1293,7 +1306,7 @@ GSL uses as its line terminator the value of of the attribute `terminator` of th
 
 #### Escape Symbol
 
-GSL uses the backslash "\" as its default escape symbol, mainly due to its POSIX / C roots. This can be very annoying in templates that have a lot of backslashes. You can override the escape symbol by changing the [gsl].escape attribute, or using the -escape:X command-line switch.
+GSL uses the backslash "\\" as its default escape symbol, mainly due to its POSIX / C roots. This can be very annoying in templates that have a lot of backslashes. You can override the escape symbol by changing the [gsl].escape attribute, or using the -escape:X command-line switch.
 
 Note that this takes effect for the next script loaded, so you cannot use this in a script to modify how that script itself is processed. You can use it before e.g. including a script.
 

--- a/README.txt
+++ b/README.txt
@@ -95,6 +95,26 @@ Finally build gsl:
     make
     make install
 
+Finally build gsl:
+
+    git clone git://github.com/zeromq/gsl
+    cd gsl/src
+    make
+    make install
+
+#### Building on MacOS 
+
+The modern way of building on MacOS is to make sure you have pcre installed and use brew.
+
+    brew install pcre
+
+And then build gsl as above:
+
+    git clone git://github.com/zeromq/gsl
+    cd gsl/src
+    make
+    sudo make install
+
 ### This Document
 
 This document was written by Pieter Hintjens in October 2010 based on two 2005 articles on 'model oriented programming', and the GSL reference manual.  This text is originally at README.txt and is built using [gitdown](http://github.com/zeromq/gitdown). The text was updated by Gyepi Sam in January 2013 to port documentation from earlier versions and to include more examples.


### PR DESCRIPTION
This PR adds MacOS build instructions and fixes a minor rendering error in Markdown where the escape symbol itself needs to be escaped in order to display it.