### PR TITLE
Problem: gsl abort() is invisible to caller in shell

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -201,6 +201,12 @@ test: everything
 check: gsl$(EXE)
 	./gsl$(EXE) testall
 	./gsl$(EXE) teststr
+	if ./gsl$(EXE) testabort ; then \
+	    echo "=== The gsl abort() returned a zero exit code, this is useless, FAIL"; \
+	    false ; \
+	else \
+	    echo "=== The gsl abort() returned non-zero exit code as expected, OK"; \
+	fi
 
 install:
 	$(INSTALL) -m 755 -d "$(bindir)"

--- a/src/ggcode.c
+++ b/src/ggcode.c
@@ -5390,6 +5390,9 @@ MODULE invoke_abort_handler (THREAD *thread)
     tcb = thread-> tcb;                 /*  Point to thread's context        */
     if (abort_fct)
         (abort_fct) ();                 /*  Call abort handler if defined    */
+    else
+        exit(EXIT_FAILURE);             /*  An abort is not an echo, so report
+                                         *  to caller that there is an issue */
 }
 
 

--- a/src/testabort.gsl
+++ b/src/testabort.gsl
@@ -1,0 +1,2 @@
+abort "Error message goes here"
+echo "Info message, you should not see this one"


### PR DESCRIPTION
Solution: set an EXIT_FAILURE by default (if no abort_handler is registered)

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Should fix https://github.com/zeromq/zproject/issues/1110 and complete the feature of https://github.com/zeromq/zproject/pull/1109