### PR TITLE
src/Makefile: separate DESTDIR and PREFIX

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -37,10 +37,9 @@
 INSTALL = /usr/bin/install -c
 
 # Installation directories, good for Debian Packaging
-DESTDIR ?= /usr/local
-prefix = ${DESTDIR}
-mandir = ${prefix}/share/man/man1
-bindir = ${prefix}/bin
+PREFIX ?= /usr/local
+mandir = ${PREFIX}/share/man/man1
+bindir = ${PREFIX}/bin
 
 RM ?= rm -f
 
@@ -209,14 +208,14 @@ check: gsl$(EXE)
 	fi
 
 install:
-	$(INSTALL) -m 755 -d "$(bindir)"
-	$(INSTALL) -m 755 gsl "$(bindir)"
-	$(INSTALL) -m 755 -d "$(mandir)"
-	$(INSTALL) -m 644 gsl.1 "$(mandir)"
+	$(INSTALL) -m 755 -d "$(DESTDIR)/$(bindir)"
+	$(INSTALL) -m 755 gsl "$(DESTDIR)/$(bindir)"
+	$(INSTALL) -m 755 -d "$(DESTDIR)/$(mandir)"
+	$(INSTALL) -m 644 gsl.1 "$(DESTDIR)/$(mandir)"
 
 uninstall:
-	$(RM) "$(bindir)/gsl"
-	$(RM) "$(mandir)/gsl.1"
+	$(RM) "$(DESTDIR)/$(bindir)/gsl"
+	$(RM) "$(DESTDIR)/$(mandir)/gsl.1"
 	@if test -d "$(bindir)" ; then \
 	    if test `find "$(bindir)" | wc -l` -le 1 ; then \
 	        echo "$(RM) -r $(bindir)" >&2 ; \


### PR DESCRIPTION
They are different things. DESTDIR is used by distributions to install
to a temporary path that will be turned into a package. PREFIX is used
to decide if one is going to install to / (root), /usr or another
desired path.

Automated build systems from distributions like Void Linux automatically
set PREFIX and DESTDIR to the proper values.