### PR TITLE
Port to PCRE2

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,7 +13,7 @@ jobs:
         include:
           - os: ubuntu-latest
             BUILD_TYPE: default
-            PACKAGES: libpcre3-dev
+            PACKAGES: libpcre2-dev
     env:
 # Set CI_TIME: true to enable build-step profiling
 # Set CI_TRACE: true to enable shell script tracing

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Godefroid Chapelle <gotcha@bubblenet.be>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y -q
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes build-essential
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes libpcre3-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes libpcre2-dev
 
 RUN mkdir /tmp/gsl
 COPY src /tmp/gsl/src

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The scripts that runs docker inside the container will place the script director
 
 Dependencies:
 
-* pcre package (e.g. libpcre3-dev)
+* pcre2 package (e.g. libpcre2-dev)
 
 To build from git on a UNIX-like box, and install into `/usr/local/bin`:
 
@@ -159,11 +159,11 @@ To show command-line help:
 
 Install GNU Make and GNU Compiler. For example, with `pkg`, `pkg install gmake gcc`. Then edit `src/Makefile` and add "-lm" to `src/Makefile` where you see CCLIBS configured. It may look similar to:
 
-    export CCLIBS = -lpcre
+    export CCLIBS = -lpcre2-8
 
 You want to add the math library:
 
-    export CCLIBS = -lpcre -lm
+    export CCLIBS = -lpcre2-8 -lm
 
 Cd to `src` and run:
 
@@ -183,7 +183,7 @@ Install git:
 
 Install gcc's dependencies:
 
-    apt-cyg install wget gcc-g++ make diffutils libmpfr-devel libgmp-devel libmpc-devel libpcre-devel libcrypt-devel
+    apt-cyg install wget gcc-g++ make diffutils libmpfr-devel libgmp-devel libmpc-devel libpcre2-devel libcrypt-devel
 
 Download, Build and Install gcc:
 
@@ -210,9 +210,9 @@ Finally build gsl:
 
 #### Building on MacOS 
 
-The modern way of building on MacOS is to make sure you have pcre installed and use brew.
+The modern way of building on MacOS is to make sure you have pcre2 installed and use brew.
 
-    brew install pcre
+    brew install pcre2
 
 And then build gsl as above:
 

--- a/README.txt
+++ b/README.txt
@@ -52,7 +52,7 @@ The scripts that runs docker inside the container will place the script director
 
 Dependencies:
 
-* pcre package (e.g. libpcre3-dev)
+* pcre2 package (e.g. libpcre2-dev)
 
 To build from git on a UNIX-like box, and install into `/usr/local/bin`:
 
@@ -73,11 +73,11 @@ To show command-line help:
 
 Install GNU Make and GNU Compiler. For example, with `pkg`, `pkg install gmake gcc`. Then edit `src/Makefile` and add "-lm" to `src/Makefile` where you see CCLIBS configured. It may look similar to:
 
-    export CCLIBS = -lpcre
+    export CCLIBS = -lpcre2-8
 
 You want to add the math library:
 
-    export CCLIBS = -lpcre -lm
+    export CCLIBS = -lpcre2-8 -lm
 
 Cd to `src` and run:
 
@@ -97,7 +97,7 @@ Install git:
 
 Install gcc's dependencies:
 
-    apt-cyg install wget gcc-g++ make diffutils libmpfr-devel libgmp-devel libmpc-devel libpcre-devel libcrypt-devel
+    apt-cyg install wget gcc-g++ make diffutils libmpfr-devel libgmp-devel libmpc-devel libpcre2-devel libcrypt-devel
 
 Download, Build and Install gcc:
 
@@ -124,9 +124,9 @@ Finally build gsl:
 
 #### Building on MacOS 
 
-The modern way of building on MacOS is to make sure you have pcre installed and use brew.
+The modern way of building on MacOS is to make sure you have pcre2 installed and use brew.
 
-    brew install pcre
+    brew install pcre2
 
 And then build gsl as above:
 

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -48,7 +48,7 @@ case "$BUILD_TYPE" in
 
     [ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
-    echo "=== What is the GSL binary linked against (note libpcre in particular)?"
+    echo "=== What is the GSL binary linked against (note libpcre2 in particular)?"
     if [ $TRAVIS_OS_NAME == "linux" ]; then
         ldd src/gsl || true
     elif [ $TRAVIS_OS_NAME == "osx" ]; then

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -49,9 +49,9 @@ case "$BUILD_TYPE" in
     [ -z "$CI_TIME" ] || echo "`date`: Builds completed without fatal errors!"
 
     echo "=== What is the GSL binary linked against (note libpcre2 in particular)?"
-    if [ $TRAVIS_OS_NAME == "linux" ]; then
+    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         ldd src/gsl || true
-    elif [ $TRAVIS_OS_NAME == "osx" ]; then
+    elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
         otool -L src/gsl || true
     else
         echo "Unsupported platform $TRAVIS_OS_NAME"

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: GSL Developers <zeromq-dev@lists.zeromq.org>
 Standards-Version: 4.1.0
 Build-Depends: debhelper (>= 9),
- libpcre3-dev,
+ libpcre2-dev,
 Homepage: https://github.com/zeromq/gsl
 
 Package: generator-scripting-language

--- a/packaging/debian/generator-scripting-language.dsc
+++ b/packaging/debian/generator-scripting-language.dsc
@@ -6,7 +6,7 @@ Maintainer: GSL Developers <zeromq-dev@lists.zeromq.org>
 Architecture: any
 Standards-Version: 4.1.0
 Build-Depends: debhelper (>= 9),
- libpcre3-dev,
+ libpcre2-dev,
 Homepage: https://github.com/zeromq/gsl
 
 Files:

--- a/packaging/linux/rpm/SPECS/generator-scripting-language.spec
+++ b/packaging/linux/rpm/SPECS/generator-scripting-language.spec
@@ -9,7 +9,7 @@ License:	GPL-3.0-or-later
 Group:		Libraries
 Source0:	http://download.zeromq.org/%{name}-%{version}.tar.gz
 URL:		http://zeromq.org/
-BuildRequires:	pcre-devel
+BuildRequires:	pcre2-devel
 
 BuildRoot:	%{tmpdir}/%{name}-%{version}-root-%(id -u -n)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,9 +50,7 @@ LIB = .a
 EXE =
 DBG =
 CC = ./c -q
-export CCLIBS = -lpcre
-
-CPPFLAGS ?= -I/usr/include/pcre
+export CCLIBS = -lpcre2-8
 
 # Reset the suffixes that will be considered to just our own list.
 #

--- a/src/ggpcre.gxl
+++ b/src/ggpcre.gxl
@@ -21,7 +21,8 @@
 <gxl script = "ggobjt.gsl" filename = "ggpcre" title = "GSL/regexp package" >
 
 <extra>
-#include <pcre.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 </extra>
 
 <class name = "regexp" title = "Regular Expression Functions" >
@@ -36,13 +37,17 @@
   {
     GGCODE_TCB
         *tcb = gsl_thread-> tcb;
-    pcre
+    pcre2_code
         *re;
+    pcre2_match_data
+        *md;
     char
         *error;
-    int 
+    int
+        errcode;
+    size_t
         erroffset;
-    int 
+    size_t
         *ovector;
     int
         oveccount,
@@ -53,47 +58,50 @@
     VALUE
         value;
 
-    re = pcre_compile (string_value (&pattern-> value),
-                       0,
-                       (const char **) &error,
-                       &erroffset,
-                       NULL);
+    re = pcre2_compile ((PCRE2_SPTR) string_value (&pattern-> value),
+                        PCRE2_ZERO_TERMINATED,
+                        0,
+                        &errcode,
+                        &erroffset,
+                        NULL);
     if (! re)
       {
+        PCRE2_UCHAR buf[120];
+
+        pcre2_get_error_message (errcode, buf, sizeof(buf));
         snprintf (object_error, LINE_MAX,
                   "Regular expression pattern error: %s\n%s\n%*c",
-                  error,
+                  buf,
                   pattern-> value. s,
-                  erroffset + 1, '^');
+                  (int) erroffset + 1, '^');
         return -1;
       }
 
-    rc = pcre_fullinfo (re,
-                        NULL,
-                        PCRE_INFO_CAPTURECOUNT,
-                        &oveccount);
+    rc = pcre2_pattern_info (re,
+                             PCRE2_INFO_CAPTURECOUNT,
+                             &oveccount);
     oveccount = (oveccount + 1) * 3;
-    ovector   = mem_alloc (oveccount * sizeof (int));
+    md        = pcre2_match_data_create (oveccount, NULL);
 
     string_value (&subject-> value);
-    rc = pcre_exec (re,
-                    NULL,
-                    subject-> value. s,
-                    (int) strlen (subject-> value. s),
-                    0,
-                    0,
-                    ovector,
-                    oveccount);
+    rc = pcre2_match (re,
+                      (PCRE2_SPTR) subject-> value. s,
+                      strlen (subject-> value. s),
+                      0,
+                      0,
+                      md,
+                      NULL);
 
-    (pcre_free) (re);
+    (pcre2_code_free) (re);
+    ovector = pcre2_get_ovector_pointer (md);
 
-    if (rc == PCRE_ERROR_NOMATCH)
+    if (rc == PCRE2_ERROR_NOMATCH)
         rc = 0;
-    else if (rc &lt; 0)
+    else if (rc < 0)
       {
         snprintf (object_error, LINE_MAX,
                  "Regular expression matching error: %d", rc);
-        mem_free (ovector);
+        pcre2_match_data_free (md);
         return -1;
       }
     else if (rc == 1)
@@ -129,7 +137,7 @@
               {
                 strncpy (object_error, error, LINE_MAX);
                 mem_free (value.s);
-                mem_free (ovector);
+                pcre2_match_data_free (md);
                 return -1;
               }
             destroy_value (& value);
@@ -137,7 +145,7 @@
         i++;
       }
 
-    mem_free (ovector);
+    pcre2_match_data_free (md);
   }
 </body>
 </function>


### PR DESCRIPTION
The original PCRE library is deprecated. This is a port to the successor PCRE2.